### PR TITLE
Gunzip fastqs

### DIFF
--- a/00_preprocess.sh
+++ b/00_preprocess.sh
@@ -18,6 +18,8 @@ ref="$HOME/ref/genomes/sacCer1/sacCer1.fa"
 
 export H5PY_DEFAULT_READONLY=1
 
+gunzip $fastq_data/*.fastq.gz
+
 multi_to_single_fast5 --input_path $fast5_data \
   --save_path $singles \
   --threads 16


### PR DESCRIPTION
Live-basecalled ONT runs produce fastq.gz, and tombo preprocess won't accept zipped files (throws an ascii codec error).